### PR TITLE
Add chat memory integration

### DIFF
--- a/chat_memory.py
+++ b/chat_memory.py
@@ -1,0 +1,44 @@
+"""High-level chat integration for MemoryAgent.
+
+This module provides a thin wrapper around :class:`memory_agent.MemoryAgent`
+so that a chat application can easily persist conversation events and other
+context into the JSON memory files.  Each helper method delegates to
+``MemoryAgent.update_memory`` which takes care of file locking and timestamp
+management.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from memory_agent import MemoryAgent
+
+
+class ChatMemory:
+    """Helper that updates memory files in response to chat events."""
+
+    def __init__(self, agent: MemoryAgent | None = None) -> None:
+        self.agent = agent or MemoryAgent()
+
+    def log_message(self, role: str, content: str, user_id: str | None = None) -> None:
+        """Record a chat message in the logs memory segment."""
+        entry = {"role": role, "content": content}
+        if user_id is not None:
+            entry["user_id"] = user_id
+        self.agent.update_memory("logs", entry)
+
+    def record_decision(self, decision: str, **details: Any) -> None:
+        """Append a decision to the decisions memory segment."""
+        entry = {"decision": decision, **details}
+        self.agent.update_memory("decisions", entry)
+
+    def update_profile(self, **profile_data: Any) -> None:
+        """Merge ``profile_data`` into the profile memory segment."""
+        self.agent.update_memory("profile", profile_data)
+
+    def update_project(self, project_id: str, **project_data: Any) -> None:
+        """Create or merge a project in the projects memory segment."""
+        entry = {"project_id": project_id, **project_data}
+        self.agent.update_memory("projects", entry)
+
+
+__all__ = ["ChatMemory"]

--- a/memory_agent.py
+++ b/memory_agent.py
@@ -1,0 +1,104 @@
+"""Utilities for reading and updating memory JSON files with file locking.
+
+This module provides a small helper class :class:`MemoryAgent` that reads and
+writes the memory JSON files stored in the repository.  Each write operation is
+protected by an exclusive file lock so parallel processes do not clobber each
+other's changes.
+
+The files track four segments of memory:
+    - decisions
+    - logs
+    - profile
+    - projects
+
+Every segment keeps a ``last_updated`` timestamp in ISO 8601 format.  When a
+segment is written through :meth:`MemoryAgent.update_memory`, the timestamp is
+refreshed automatically.  For list‑based segments (``decisions``, ``logs`` and
+``projects``) the new entry also receives its own ``last_updated`` field.
+"""
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import fcntl
+
+
+@contextmanager
+def _locked_file(path: str, mode: str):
+    """Open *path* and lock it for the duration of the context."""
+    with open(path, mode) as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield fh
+        finally:
+            fh.flush()
+            os.fsync(fh.fileno())
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def _iso_now() -> str:
+    """Return the current UTC time in ISO 8601 format."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class MemoryAgent:
+    """Helper for reading and updating memory JSON files."""
+
+    def __init__(self, base_dir: str | None = None) -> None:
+        self.base_dir = base_dir or os.path.dirname(__file__)
+        self.files = {
+            "decisions": os.path.join(self.base_dir, "memory_decisions_v2.json"),
+            "logs": os.path.join(self.base_dir, "memory_logs_v2.json"),
+            "profile": os.path.join(self.base_dir, "memory_profile_v2.json"),
+            "projects": os.path.join(self.base_dir, "memory_projects_v2.json"),
+        }
+
+    def _read_json(self, segment: str) -> Dict[str, Any]:
+        with _locked_file(self.files[segment], "r") as fh:
+            return json.load(fh)
+
+    def _write_json(self, segment: str, data: Dict[str, Any]) -> None:
+        with _locked_file(self.files[segment], "w") as fh:
+            json.dump(data, fh, ensure_ascii=False)
+
+    def update_memory(self, segment: str, entry: Dict[str, Any]) -> None:
+        """Update *segment* with *entry* and refresh timestamps.
+
+        Parameters
+        ----------
+        segment:
+            One of ``decisions``, ``logs``, ``profile`` or ``projects``.
+        entry:
+            Data to merge into the segment.  For list‑based segments the entry
+            is appended (or merged for projects with the same ``project_id``).
+        """
+        data = self._read_json(segment)
+        now = _iso_now()
+        data["last_updated"] = now
+
+        if segment == "profile":
+            data.setdefault("data", {}).update(entry)
+            data["data"]["last_updated"] = now
+        elif segment in {"decisions", "logs"}:
+            entry = dict(entry)
+            entry["last_updated"] = now
+            data[segment].append(entry)
+        elif segment == "projects":
+            entry = dict(entry)
+            entry["last_updated"] = now
+            pid = entry.get("project_id")
+            projects = data.setdefault("projects", [])
+            for idx, proj in enumerate(projects):
+                if proj.get("project_id") == pid:
+                    projects[idx].update(entry)
+                    break
+            else:
+                projects.append(entry)
+        else:
+            raise ValueError(f"Unknown segment: {segment}")
+
+        self._write_json(segment, data)

--- a/memory_decisions_v2.json
+++ b/memory_decisions_v2.json
@@ -1,1 +1,7 @@
-{"segment":"decisions","retention_days":30,"decisions":[],"version":"2.2"}
+{
+  "segment": "decisions",
+  "retention_days": 30,
+  "decisions": [],
+  "version": "2.2",
+  "last_updated": "2025-08-22T18:27:20.740619Z"
+}

--- a/memory_logs_v2.json
+++ b/memory_logs_v2.json
@@ -1,1 +1,7 @@
-{"segment":"logs","retention_days":90,"logs":[],"version":"2.2"}
+{
+  "segment": "logs",
+  "retention_days": 90,
+  "logs": [],
+  "version": "2.2",
+  "last_updated": "2025-08-22T18:27:20.740619Z"
+}

--- a/memory_projects_v2.json
+++ b/memory_projects_v2.json
@@ -1,1 +1,14 @@
-{"segment":"projects","retention_days":30,"projects":[{"project_id":"844302d9-1502-4c42-acf4-3f20c74fd3cb","name":"JOJIAI Launch","status":"in_progress"}],"version":"2.2"}
+{
+  "segment": "projects",
+  "retention_days": 30,
+  "projects": [
+    {
+      "project_id": "844302d9-1502-4c42-acf4-3f20c74fd3cb",
+      "name": "JOJIAI Launch",
+      "status": "in_progress",
+      "last_updated": "2025-08-22T18:27:20.740619Z"
+    }
+  ],
+  "version": "2.2",
+  "last_updated": "2025-08-22T18:27:20.740619Z"
+}


### PR DESCRIPTION
## Summary
- add ChatMemory helper that wires chat events to MemoryAgent updates

## Testing
- `python -m py_compile memory_agent.py chat_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b4f96dd08324b420590eca77844b